### PR TITLE
change package version and measurement units

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-lxd (3.18-1) UNRELEASED; urgency=low
+lxd (3.18-99) UNRELEASED; urgency=low
 
   * Initial LXD repack
 

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -97,13 +97,13 @@ lxc config device set test eth0 ipv4.address IP
 
 # add fixed size disk (with project quota enabled)
 lxc config device add test root disk pool=default path=/
-lxc config device set test root size 8GB
+lxc config device set test root size 8GiB
 
 # set cpu limit
 lxc config set test limits.cpu 2
 
 # set memory limit
-lxc config set test limits.memory 1024MB
+lxc config set test limits.memory 1024MiB
 lxc config set test limits.memory.enforce hard
 
 # disable swap


### PR DESCRIPTION
Gigabytes/Megabytes gives power of 1000, Gibibytes/Mibibytes gives power of 1024.
It seems LXD uses IEC (not JEDEC) metrics.