### PR TITLE
fix systemd parse lxd.service error

### DIFF
--- a/overlay/lib/systemd/system/lxd.service
+++ b/overlay/lib/systemd/system/lxd.service
@@ -20,7 +20,6 @@ LimitFSIZE=infinity
 LimitLOCKS=infinity
 LimitMEMLOCK=infinity
 LimitMSGQUEUE=infinity
-LimitNICE=infinity
 LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitRSS=infinity


### PR DESCRIPTION
It fixes systemd parse error:
/lib/systemd/system/lxd.service:22: Failed to parse resource value, ignoring: infinity


Signed-off-by: Maksim Kaut <maksimkaut92@gmail.com>